### PR TITLE
Pull internal token lazily for status update

### DIFF
--- a/cwms_batch_events/lambdas/update_batch_job_status/status_updater.py
+++ b/cwms_batch_events/lambdas/update_batch_job_status/status_updater.py
@@ -55,13 +55,6 @@ def get_internal_token() -> str:
 
 
 def lambda_handler(event, context):
-    internal_token = get_internal_token()
-
-    headers = {
-        "Content-Type": "application/json",
-        "X-Internal-Token": internal_token,
-    }
-
     logger.info("Received Batch job state change event from EventBridge")
 
     try:
@@ -91,6 +84,13 @@ def lambda_handler(event, context):
     except KeyError:
         logger.info("Ignoring unsupported Batch status: %s", raw_status)
         return
+
+    internal_token = get_internal_token()
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-Internal-Token": internal_token,
+    }
 
     payload = {"status": status, "event_time": time_iso}
     try:


### PR DESCRIPTION
Avoid unnecessarily pulling the internal token within the status updater lambda for ignored Batch events, e.g. cron jobs. Reduces lambda execution time.