### PR TITLE
29 implement unit testing for existing components

### DIFF
--- a/.github/workflows/cwbi-test-push-api.yml
+++ b/.github/workflows/cwbi-test-push-api.yml
@@ -1,0 +1,48 @@
+name: Python Tests on PR
+
+on:
+  pull_request:
+    branches:
+      - cwbi-dev
+      - cwbi-test
+      - cwbi-prod
+    paths:
+      - "cwms_batch_events/**"
+      - "tests/**"
+      - "requirements.txt"
+      - "requirements-dev.txt"
+      - "pytest.ini"
+      - ".github/workflows/cwbi-test-push-api.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        run: pytest --cov-report=html
+
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-htmlcov
+          path: htmlcov/

--- a/.github/workflows/cwbi-test-push-api.yml
+++ b/.github/workflows/cwbi-test-push-api.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install -r requirements-dev.txt
 
       - name: Run pytest
-        run: pytest --cov-report=html
+        run: pytest --cov-report=html --cov-report=json
 
       - name: Upload coverage HTML report
         if: always()
@@ -46,3 +46,27 @@ jobs:
         with:
           name: python-htmlcov
           path: htmlcov/
+
+      - name: Add coverage summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          coverage_file = Path("coverage.json")
+          if not coverage_file.exists():
+              raise SystemExit("coverage.json was not generated")
+
+          data = json.loads(coverage_file.read_text())
+          total = data["totals"]["percent_covered_display"]
+
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          summary.write_text(
+              "## Python Coverage\n\n"
+              f"- Total coverage: `{total}%`\n"
+              "- HTML report: download the `python-htmlcov` artifact from this workflow run.\n",
+              encoding="utf-8",
+          )
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
+coverage.json
 .cache
 nosetests.xml
 coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,6 @@
 * Type Standardization
   * TypeScript types are generated from the API for use in the frontend using [OpenAPI TypeScript](https://openapi-ts.dev/). 
   * If API types are updated or modified, run `npm run generate:types` to update the type definitions.
+* Python Testing
+  * Run `pytest` from the project root to execute the Python unit test suite.
+  * The suite is configured to report coverage for `cwms_batch_events` and should stay fast and free of external dependencies.

--- a/cwms_batch_events/api/routers/scripts.py
+++ b/cwms_batch_events/api/routers/scripts.py
@@ -63,7 +63,7 @@ def post_script(
         return job_db.store_script(payload)
     except ValueError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)
         )
     except SlugError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
@@ -87,7 +87,7 @@ def put_script(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(e))
     except ValueError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)
         )
 
 

--- a/cwms_batch_events/lambdas/dispatch_job/dispatcher.py
+++ b/cwms_batch_events/lambdas/dispatch_job/dispatcher.py
@@ -100,6 +100,7 @@ def lambda_handler(event, context):
             external_job_id = dispatch_job(message)
         except ClientError:
             logger.exception("Failed to submit batch job for message: %s", message)
+            raise
 
         try:
             bind_request = BindExternalJobIdRequest(external_job_id=external_job_id)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+addopts = -ra --strict-markers --cov=cwms_batch_events --cov-branch --cov-report=term-missing
+markers =
+    unit: fast isolated tests
+    integration: tests that exercise component boundaries

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 pytest
 pytest-cov
+pytest-trio
 docker

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest
+pytest-cov
 docker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("ALB_DNS_NAME", "http://events")
+os.environ.setdefault("APP_SECRETS_ARN", "arn:aws:secretsmanager:test")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-gov-west-1")

--- a/tests/cwms_batch_events/api/conftest.py
+++ b/tests/cwms_batch_events/api/conftest.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cwms_batch_events.api.dependencies import (
+    get_current_user,
+    get_job_database,
+    get_job_logger,
+    get_job_queue,
+)
+from cwms_batch_events.api.main import app
+from cwms_batch_events.core.auth.service.dependencies import require_internal_auth
+from cwms_batch_events.core.auth.user.models import User
+from tests.factories import make_user
+
+
+@pytest.fixture
+def user() -> User:
+    return make_user()
+
+
+@pytest.fixture
+def job_db():
+    return MagicMock()
+
+
+@pytest.fixture
+def job_logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def job_queue():
+    return MagicMock()
+
+
+@pytest.fixture
+def client(user: User, job_db: MagicMock, job_logger: MagicMock, job_queue: MagicMock):
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_job_database] = lambda: job_db
+    app.dependency_overrides[get_job_logger] = lambda: job_logger
+    app.dependency_overrides[get_job_queue] = lambda: job_queue
+    app.dependency_overrides[require_internal_auth] = lambda: True
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()

--- a/tests/cwms_batch_events/api/test_dependencies.py
+++ b/tests/cwms_batch_events/api/test_dependencies.py
@@ -1,0 +1,75 @@
+from unittest import mock
+
+from cwms_batch_events.api import dependencies
+
+
+def test_get_db_session_closes_session():
+    session = mock.Mock()
+
+    with mock.patch(
+        "cwms_batch_events.api.dependencies.create_session",
+        return_value=session,
+    ):
+        generator = dependencies.get_db_session()
+        yielded = next(generator)
+
+        assert yielded is session
+
+        try:
+            next(generator)
+        except StopIteration:
+            pass
+
+    session.close.assert_called_once()
+
+
+def test_get_job_database_wraps_session_in_postgres_job_database():
+    session = object()
+
+    with mock.patch(
+        "cwms_batch_events.api.dependencies.PostgresJobDatabase",
+        return_value="db",
+    ) as postgres_db:
+        db = dependencies.get_job_database(session)
+
+    assert db == "db"
+    postgres_db.assert_called_once_with(db=session)
+
+
+def test_get_job_logger_uses_s3_for_local_runner():
+    with mock.patch(
+        "cwms_batch_events.api.dependencies.settings.default_job_runner", "docker-local"
+    ), mock.patch(
+        "cwms_batch_events.api.dependencies.S3JobLogger",
+        return_value="logger",
+    ) as s3_logger:
+        logger = dependencies.get_job_logger(mock.Mock())
+
+    assert logger == "logger"
+    s3_logger.assert_called_once_with()
+
+
+def test_get_job_logger_uses_cloudwatch_for_batch_runner():
+    db = mock.Mock()
+
+    with mock.patch(
+        "cwms_batch_events.api.dependencies.settings.default_job_runner", "batch"
+    ), mock.patch(
+        "cwms_batch_events.api.dependencies.CloudWatchJobLogger",
+        return_value="logger",
+    ) as cloudwatch_logger:
+        logger = dependencies.get_job_logger(db)
+
+    assert logger == "logger"
+    cloudwatch_logger.assert_called_once_with(db)
+
+
+def test_get_job_queue_constructs_job_queue():
+    with mock.patch(
+        "cwms_batch_events.api.dependencies.JobQueue",
+        return_value="queue",
+    ) as job_queue_cls:
+        queue = dependencies.get_job_queue()
+
+    assert queue == "queue"
+    job_queue_cls.assert_called_once_with()

--- a/tests/cwms_batch_events/api/test_health.py
+++ b/tests/cwms_batch_events/api/test_health.py
@@ -1,0 +1,5 @@
+def test_health_returns_ok(client):
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/cwms_batch_events/api/test_internal.py
+++ b/tests/cwms_batch_events/api/test_internal.py
@@ -1,0 +1,73 @@
+from uuid import uuid4
+from unittest import mock
+import pytest
+
+
+def test_update_batch_job_status_returns_no_content(client, job_db):
+    with mock.patch("cwms_batch_events.api.routers.internal.update_batch_job_status"):
+        response = client.post(
+            "/internal/batch-jobs/batch-123/status",
+            json={"status": "Running", "event_time": "2026-04-16T12:00:00Z"},
+        )
+
+    assert response.status_code == 204
+    job_db.update_job_status.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_status", "expected_detail"),
+    [
+        (ValueError("bad status"), 400, "bad status"),
+        (RuntimeError("boom"), 500, "boom"),
+    ],
+)
+def test_update_batch_job_status_maps_errors(client, side_effect, expected_status, expected_detail):
+    with mock.patch(
+        "cwms_batch_events.api.routers.internal.update_batch_job_status",
+        side_effect=side_effect,
+    ):
+        response = client.post(
+            "/internal/batch-jobs/batch-123/status",
+            json={"status": "Running", "event_time": "2026-04-16T12:00:00Z"},
+        )
+
+    assert response.status_code == expected_status
+    assert response.json() == {"detail": expected_detail}
+
+
+def test_bind_external_job_id_returns_no_content(client, job_db):
+    job_id = str(uuid4())
+
+    response = client.post(
+        f"/internal/jobs/{job_id}/external-job-id",
+        json={"external_job_id": "batch-123"},
+    )
+
+    assert response.status_code == 204
+    job_db.bind_external_job_id.assert_called_once()
+
+
+def test_bind_external_job_id_maps_value_error_to_400(client, job_db):
+    job_db.bind_external_job_id.side_effect = ValueError("already bound")
+    job_id = str(uuid4())
+
+    response = client.post(
+        f"/internal/jobs/{job_id}/external-job-id",
+        json={"external_job_id": "batch-123"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "already bound"}
+
+
+def test_bind_external_job_id_maps_generic_error_to_500(client, job_db):
+    job_db.bind_external_job_id.side_effect = RuntimeError("boom")
+    job_id = str(uuid4())
+
+    response = client.post(
+        f"/internal/jobs/{job_id}/external-job-id",
+        json={"external_job_id": "batch-123"},
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "boom"}

--- a/tests/cwms_batch_events/api/test_jobs.py
+++ b/tests/cwms_batch_events/api/test_jobs.py
@@ -1,0 +1,90 @@
+import pytest
+from uuid import uuid4
+
+from sqlalchemy.exc import NoResultFound
+
+from cwms_batch_events.core.models import JobSource
+from tests.factories import make_job_record
+
+
+def test_get_jobs_for_user_returns_jobs(client, job_db, user):
+    job = make_job_record()
+    job_db.get_jobs_for_user.return_value = [job]
+
+    response = client.get("/jobs")
+
+    assert response.status_code == 200
+    assert response.json()[0]["id"] == str(job.id)
+    job_db.get_jobs_for_user.assert_called_once_with(user.username)
+
+
+def test_post_job_creates_and_dispatches_message(client, job_db, job_queue):
+    script_id = str(uuid4())
+    job = make_job_record()
+    job_db.create_job.return_value = job
+    message = object()
+    job_queue.create_job_message.return_value = message
+
+    response = client.post("/jobs", json={"scriptId": script_id})
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(job.id)
+    job_db.create_job.assert_called_once()
+    job_queue.create_job_message.assert_called_once()
+    create_call = job_queue.create_job_message.call_args
+    assert create_call.args[0] == job.id
+    assert create_call.args[1] == "test-user"
+    assert create_call.args[2] == JobSource.API
+    assert create_call.args[3].office == "swt"
+    assert create_call.args[3].repo_path == job.repo_path
+    assert create_call.args[3].script_slug == job.script_slug
+    job_queue.send_job_message.assert_called_once_with(message)
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_status", "expected_detail_factory"),
+    [
+        (PermissionError("nope"), 403, lambda script_id: "nope"),
+        (NoResultFound(), 404, lambda script_id: f"Script {script_id} not found"),
+    ],
+)
+def test_post_job_maps_errors(client, job_db, side_effect, expected_status, expected_detail_factory):
+    script_id = str(uuid4())
+    job_db.create_job.side_effect = side_effect
+
+    response = client.post("/jobs", json={"scriptId": script_id})
+
+    assert response.status_code == expected_status
+    assert response.json() == {"detail": expected_detail_factory(script_id)}
+
+
+def test_get_job_by_id_returns_job(client, job_db):
+    job = make_job_record()
+    job_db.get_job_by_id.return_value = job
+
+    response = client.get(f"/jobs/{job.id}")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(job.id)
+    job_db.get_job_by_id.assert_called_once_with(job.id)
+
+
+def test_get_job_by_id_returns_404_when_missing(client, job_db):
+    job_id = str(uuid4())
+    job_db.get_job_by_id.return_value = None
+
+    response = client.get(f"/jobs/{job_id}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"No job found for jobId '{job_id}'"}
+
+
+def test_get_logs_for_job_returns_logs(client, job_logger):
+    job_id = str(uuid4())
+    job_logger.get_logs_for_job.return_value = "hello"
+
+    response = client.get(f"/jobs/{job_id}/logs")
+
+    assert response.status_code == 200
+    assert response.json() == {"logs": "hello"}
+    job_logger.get_logs_for_job.assert_called_once()

--- a/tests/cwms_batch_events/api/test_scripts.py
+++ b/tests/cwms_batch_events/api/test_scripts.py
@@ -1,0 +1,133 @@
+import pytest
+from uuid import uuid4
+
+from sqlalchemy.exc import NoResultFound
+
+from cwms_batch_events.core.job_database.postgres.postgres import SlugError
+from tests.factories import make_script_create_payload, make_script_payload, make_script_read
+
+
+def test_get_scripts_for_office_requires_admin_access(client):
+    response = client.get("/scripts", params={"office": "LRH"})
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": "User does not have script admin access for office 'LRH'"
+    }
+
+
+def test_get_scripts_for_office_returns_scripts(client, job_db):
+    script = make_script_read()
+    job_db.get_scripts_for_office.return_value = [script]
+
+    response = client.get("/scripts", params={"office": "SWT"})
+
+    assert response.status_code == 200
+    assert response.json()[0]["id"] == str(script.id)
+    job_db.get_scripts_for_office.assert_called_once_with("SWT")
+
+
+def test_post_script_returns_created_script(client, job_db):
+    script = make_script_read()
+    job_db.store_script.return_value = script
+
+    response = client.post("/scripts", json=make_script_create_payload())
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(script.id)
+    job_db.store_script.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_status", "expected_detail"),
+    [
+        (ValueError("bad payload"), 422, "bad payload"),
+        (SlugError("slug in use"), 409, "slug in use"),
+    ],
+)
+def test_post_script_maps_errors(client, job_db, side_effect, expected_status, expected_detail):
+    job_db.store_script.side_effect = side_effect
+
+    response = client.post("/scripts", json=make_script_create_payload())
+
+    assert response.status_code == expected_status
+    assert response.json() == {"detail": expected_detail}
+
+
+def test_put_script_returns_updated_script(client, job_db):
+    script = make_script_read()
+    job_db.update_script.return_value = script
+
+    response = client.put(f"/scripts/{script.id}", json=make_script_payload())
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(script.id)
+    job_db.update_script.assert_called_once()
+
+
+def test_put_script_returns_404_when_missing(client, job_db):
+    job_db.update_script.side_effect = NoResultFound()
+    script_id = str(uuid4())
+
+    response = client.put(f"/scripts/{script_id}", json=make_script_payload())
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Script {script_id} not found"}
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_status", "expected_detail"),
+    [
+        (PermissionError("no access"), 401, "no access"),
+        (ValueError("bad payload"), 422, "bad payload"),
+    ],
+)
+def test_put_script_maps_other_errors(client, job_db, side_effect, expected_status, expected_detail):
+    job_db.update_script.side_effect = side_effect
+
+    response = client.put(f"/scripts/{uuid4()}", json=make_script_payload())
+
+    assert response.status_code == expected_status
+    assert response.json() == {"detail": expected_detail}
+
+
+def test_delete_script_returns_no_content(client, job_db):
+    script_id = str(uuid4())
+
+    response = client.delete(f"/scripts/{script_id}")
+
+    assert response.status_code == 204
+    job_db.remove_script_if_allowed.assert_called_once()
+
+
+def test_delete_script_returns_404_when_missing(client, job_db):
+    job_db.remove_script_if_allowed.side_effect = NoResultFound()
+    script_id = str(uuid4())
+
+    response = client.delete(f"/scripts/{script_id}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Script {script_id} not found"}
+
+
+def test_delete_script_returns_401_for_permission_error(client, job_db):
+    script_id = str(uuid4())
+    job_db.remove_script_if_allowed.side_effect = PermissionError("no access")
+
+    response = client.delete(f"/scripts/{script_id}")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "no access"}
+
+
+def test_get_scripts_catalog_returns_role_filtered_catalog(client, job_db):
+    script = make_script_read()
+    job_db.retrieve_script_catalog.return_value = [script]
+
+    response = client.get("/scripts/catalog")
+
+    assert response.status_code == 200
+    assert response.json()[0]["id"] == str(script.id)
+    job_db.retrieve_script_catalog.assert_called_once_with(
+        {"SWT": ["CWMS Users"], "LRH": ["CWMS Users"]}
+    )

--- a/tests/cwms_batch_events/api/test_users.py
+++ b/tests/cwms_batch_events/api/test_users.py
@@ -1,0 +1,5 @@
+def test_get_admin_offices_returns_current_user_admin_offices(client, user):
+    response = client.get("/users/me/admin-offices")
+
+    assert response.status_code == 200
+    assert response.json() == user.admin_offices

--- a/tests/cwms_batch_events/core/auth/service/test_service_auth.py
+++ b/tests/cwms_batch_events/core/auth/service/test_service_auth.py
@@ -38,3 +38,10 @@ def test_valid_token_succeeds(internal_auth_token):
     r = client.post("/internal", headers={"X-Internal-Token": internal_auth_token})
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}
+
+
+def test_missing_app_key_returns_500():
+    with mock.patch("cwms_batch_events.core.settings.settings.app_key", ""):
+        r = client.post("/internal", headers={"X-Internal-Token": "anything"})
+
+    assert r.status_code == 500

--- a/tests/cwms_batch_events/core/auth/user/test_jwt.py
+++ b/tests/cwms_batch_events/core/auth/user/test_jwt.py
@@ -1,0 +1,102 @@
+from unittest import mock
+
+import pytest
+
+from cwms_batch_events.core.auth.user.jwt import (
+    get_public_pem,
+    raw_key_to_pem,
+    verify_jwt,
+    verify_jwt_by_api,
+    verify_jwt_by_saved_key,
+)
+
+
+def test_raw_key_to_pem_wraps_public_key():
+    pem = raw_key_to_pem("abc123")
+
+    assert pem == "-----BEGIN PUBLIC KEY-----\nabc123\n-----END PUBLIC KEY-----"
+
+
+def test_get_public_pem_uses_current_auth_environment():
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.settings.auth_environment", "TEST"
+    ):
+        pem = get_public_pem()
+
+    assert pem.startswith("-----BEGIN PUBLIC KEY-----")
+    assert pem.endswith("-----END PUBLIC KEY-----")
+
+
+def test_get_public_pem_raises_for_unknown_environment():
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.settings.auth_environment", "BOGUS"
+    ):
+        with pytest.raises(KeyError):
+            get_public_pem()
+
+
+def test_verify_jwt_routes_local_to_api_verification():
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.settings.auth_environment", "LOCAL"
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.verify_jwt_by_api",
+        return_value={"sub": "123"},
+    ) as verify_api:
+        payload = verify_jwt("token")
+
+    assert payload == {"sub": "123"}
+    verify_api.assert_called_once_with("token")
+
+
+def test_verify_jwt_routes_non_local_to_saved_key_verification():
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.settings.auth_environment", "TEST"
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.verify_jwt_by_saved_key",
+        return_value={"sub": "123"},
+    ) as verify_saved:
+        payload = verify_jwt("token")
+
+    assert payload == {"sub": "123"}
+    verify_saved.assert_called_once_with("token")
+
+
+def test_verify_jwt_by_api_uses_jwks_client():
+    jwks_client = mock.Mock()
+    signing_key = mock.Mock(key="pubkey")
+    jwks_client.get_signing_key_from_jwt.return_value = signing_key
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.PyJWKClient",
+        return_value=jwks_client,
+    ) as jwk_client_cls, mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.jwt.decode",
+        return_value={"sub": "123"},
+    ) as jwt_decode:
+        payload = verify_jwt_by_api("token")
+
+    assert payload == {"sub": "123"}
+    jwk_client_cls.assert_called_once()
+    jwt_decode.assert_called_once_with("token", signing_key, ["RS256"])
+
+
+def test_verify_jwt_by_saved_key_uses_saved_public_key_and_issuer():
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.settings.auth_environment", "TEST"
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.get_public_pem",
+        return_value="pem",
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.jwt.jwt.decode",
+        return_value={"sub": "123"},
+    ) as jwt_decode:
+        payload = verify_jwt_by_saved_key("token")
+
+    assert payload == {"sub": "123"}
+    jwt_decode.assert_called_once_with(
+        "token",
+        "pem",
+        algorithms=["RS256"],
+        issuer="https://identity-test.cwbi.us/auth/realms/cwbi",
+        options={"verify_aud": False},
+    )

--- a/tests/cwms_batch_events/core/auth/user/test_roles.py
+++ b/tests/cwms_batch_events/core/auth/user/test_roles.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from cwms_batch_events.core.auth.user.roles import (
+    get_user_admin_offices,
+    get_user_allowed_offices,
+    get_user_profile_apikey,
+    get_user_profile_jwt,
+)
+
+
+def test_get_user_profile_apikey_calls_cda_with_apikey_header():
+    response = mock.Mock()
+    response.json.return_value = {
+        "user-name": "tester",
+        "cac-auth": False,
+        "roles": {"SWT": ["CWMS Users"]},
+    }
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.roles.requests.get",
+        return_value=response,
+    ) as requests_get, mock.patch(
+        "cwms_batch_events.core.auth.user.roles.CDA_API_ROOT",
+        "http://example/",
+    ):
+        profile = get_user_profile_apikey("secret")
+
+    assert profile.user_name == "tester"
+    requests_get.assert_called_once_with(
+        "http://example/user/profile",
+        headers={"accept": "application/json", "Authorization": "apikey secret"},
+    )
+
+
+def test_get_user_profile_jwt_calls_cda_with_bearer_header():
+    response = mock.Mock()
+    response.json.return_value = {
+        "user-name": "tester",
+        "cac-auth": False,
+        "roles": {"SWT": ["CWMS Users"]},
+    }
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.roles.requests.get",
+        return_value=response,
+    ) as requests_get, mock.patch(
+        "cwms_batch_events.core.auth.user.roles.CDA_API_ROOT",
+        "http://example/",
+    ):
+        profile = get_user_profile_jwt("token")
+
+    assert profile.user_name == "tester"
+    requests_get.assert_called_once_with(
+        "http://example/user/profile",
+        headers={"accept": "application/json", "Authorization": "Bearer token"},
+    )
+
+
+def test_get_user_profile_requires_cda_api_root():
+    with mock.patch("cwms_batch_events.core.auth.user.roles.CDA_API_ROOT", ""):
+        with pytest.raises(ValueError, match="No CDA_API_ROOT"):
+            get_user_profile_apikey("secret")
+
+
+def test_get_user_profile_jwt_requires_cda_api_root():
+    with mock.patch("cwms_batch_events.core.auth.user.roles.CDA_API_ROOT", ""):
+        with pytest.raises(ValueError, match="No CDA_API_ROOT"):
+            get_user_profile_jwt("token")
+
+
+def test_get_user_allowed_offices_filters_to_cwms_users():
+    cda_user = SimpleNamespace(
+        roles={
+            "SWT": ["CWMS Users", "Viewer Users"],
+            "LRH": ["Viewer Users"],
+            "MVK": ["CWMS Users"],
+        }
+    )
+
+    assert get_user_allowed_offices(cda_user) == ["SWT", "MVK"]
+
+
+def test_get_user_admin_offices_filters_to_admin_roles():
+    cda_user = SimpleNamespace(
+        roles={
+            "SWT": ["Data Exchange Mgr"],
+            "LRH": ["Viewer Users"],
+            "MVK": ["Data Acquisition Mgr", "CWMS Users"],
+        }
+    )
+
+    assert get_user_admin_offices(cda_user) == ["SWT", "MVK"]

--- a/tests/cwms_batch_events/core/auth/user/test_user_dependencies.py
+++ b/tests/cwms_batch_events/core/auth/user/test_user_dependencies.py
@@ -1,0 +1,185 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from cwms_batch_events.core.auth.user.dependencies import (
+    get_auth_credentials,
+    get_current_user_cwms,
+    get_current_user_mock,
+    user_cache,
+)
+
+
+class DummyRequest:
+    def __init__(self, authorization: str | None):
+        self.headers = {}
+        if authorization is not None:
+            self.headers["Authorization"] = authorization
+
+
+@pytest.fixture(autouse=True)
+def clear_user_cache():
+    user_cache.clear()
+    yield
+    user_cache.clear()
+
+
+@pytest.mark.anyio
+async def test_get_auth_credentials_requires_authorization_header():
+    with pytest.raises(HTTPException) as exc_info:
+        await get_auth_credentials(DummyRequest(None), "docs")
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Missing Authorization header"
+
+
+@pytest.mark.anyio
+async def test_get_auth_credentials_requires_two_part_header():
+    with pytest.raises(HTTPException) as exc_info:
+        await get_auth_credentials(DummyRequest("Bearer"), "docs")
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid Authorization header"
+
+
+@pytest.mark.anyio
+async def test_get_auth_credentials_parses_scheme_and_credentials():
+    credentials = await get_auth_credentials(DummyRequest("Bearer token"), "docs")
+
+    assert credentials.scheme == "Bearer"
+    assert credentials.credentials == "token"
+
+
+@pytest.mark.anyio
+async def test_get_current_user_cwms_builds_user_from_bearer_token():
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+    cda_user = SimpleNamespace(
+        user_name="tester",
+        roles={"SWT": ["CWMS Users", "Data Exchange Mgr"]},
+    )
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.verify_jwt",
+        return_value={"azp": "cwms"},
+    ) as verify_jwt_mock, mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_profile_jwt",
+        return_value=cda_user,
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_allowed_offices",
+        return_value=["SWT"],
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_admin_offices",
+        return_value=["SWT"],
+    ):
+        user = await get_current_user_cwms(credentials)
+
+    assert user.username == "tester"
+    assert user.offices == ["SWT"]
+    assert user.admin_offices == ["SWT"]
+    verify_jwt_mock.assert_called_once_with("token")
+
+
+@pytest.mark.anyio
+async def test_get_current_user_cwms_rejects_unsupported_scheme():
+    credentials = HTTPAuthorizationCredentials(scheme="Basic", credentials="secret")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user_cwms(credentials)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Unsupported auth scheme: Basic"
+
+
+@pytest.mark.anyio
+async def test_get_current_user_cwms_rejects_invalid_bearer_token():
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.verify_jwt",
+        side_effect=Exception("bad token"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_cwms(credentials)
+
+    assert exc_info.value.status_code == 401
+    assert "Invalid token: bad token" in exc_info.value.detail
+
+
+@pytest.mark.anyio
+async def test_get_current_user_cwms_rejects_wrong_azp():
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.verify_jwt",
+        return_value={"azp": "not-cwms"},
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_cwms(credentials)
+
+    assert exc_info.value.status_code == 401
+    assert "not authorized" in exc_info.value.detail
+
+
+@pytest.mark.anyio
+async def test_get_current_user_cwms_builds_user_from_apikey():
+    credentials = HTTPAuthorizationCredentials(scheme="apikey", credentials="secret")
+    cda_user = SimpleNamespace(
+        user_name="tester",
+        roles={"SWT": ["CWMS Users"]},
+    )
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_profile_apikey",
+        return_value=cda_user,
+    ) as get_profile, mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_allowed_offices",
+        return_value=["SWT"],
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_admin_offices",
+        return_value=[],
+    ):
+        user = await get_current_user_cwms(credentials)
+
+    assert user.username == "tester"
+    assert user.offices == ["SWT"]
+    assert user.admin_offices == []
+    get_profile.assert_called_once_with("secret")
+
+
+@pytest.mark.anyio
+async def test_get_current_user_cwms_uses_cache():
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+    cda_user = SimpleNamespace(user_name="tester", roles={"SWT": ["CWMS Users"]})
+
+    with mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.verify_jwt",
+        return_value={"azp": "cwms"},
+    ) as verify_jwt_mock, mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_profile_jwt",
+        return_value=cda_user,
+    ) as get_profile, mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_allowed_offices",
+        return_value=["SWT"],
+    ), mock.patch(
+        "cwms_batch_events.core.auth.user.dependencies.get_user_admin_offices",
+        return_value=[],
+    ):
+        first = await get_current_user_cwms(credentials)
+        second = await get_current_user_cwms(credentials)
+
+    assert first == second
+    verify_jwt_mock.assert_called_once_with("token")
+    get_profile.assert_called_once_with("token")
+
+
+@pytest.mark.anyio
+async def test_get_current_user_mock_returns_full_access_user():
+    user = await get_current_user_mock()
+
+    assert user.username == "dev-user"
+    assert "SWT" in user.offices
+    assert "SWT" in user.admin_offices
+    assert "SWT" in user.roles

--- a/tests/cwms_batch_events/core/test_batch_job_status_update.py
+++ b/tests/cwms_batch_events/core/test_batch_job_status_update.py
@@ -7,84 +7,48 @@ from cwms_batch_events.core.models import JobStatus
 from cwms_batch_events.core.processing import update_batch_job_status
 
 
-def test_update_running_status():
+@pytest.mark.parametrize(
+    ("current_status", "new_status"),
+    [
+        (JobStatus.PENDING, JobStatus.RUNNING),
+        (JobStatus.RUNNING, JobStatus.COMPLETED),
+        (JobStatus.RUNNING, JobStatus.FAILED),
+    ],
+)
+def test_update_higher_priority_status(current_status, new_status):
     mock_db = MagicMock()
     job = MagicMock()
     job.id = 123
-    job.job_status = JobStatus.PENDING
+    job.job_status = current_status
     mock_db.get_job_by_external_id.return_value = job
 
     update_batch_job_status(
         batch_job_id="abc",
-        status=JobStatus.RUNNING,
+        status=new_status,
         time_iso=datetime.now(timezone.utc),
         db=mock_db,
     )
 
-    mock_db.update_job_status.assert_any_call(123, JobStatus.RUNNING)
+    mock_db.update_job_status.assert_called_once_with(123, new_status)
 
 
-def test_update_completed_status():
+@pytest.mark.parametrize(
+    ("current_status", "new_status"),
+    [
+        (JobStatus.RUNNING, JobStatus.RUNNING),
+        (JobStatus.COMPLETED, JobStatus.RUNNING),
+    ],
+)
+def test_update_duplicate_or_lower_priority_status(current_status, new_status):
     mock_db = MagicMock()
     job = MagicMock()
     job.id = 123
-    job.job_status = JobStatus.RUNNING
+    job.job_status = current_status
     mock_db.get_job_by_external_id.return_value = job
 
     update_batch_job_status(
         batch_job_id="abc",
-        status=JobStatus.COMPLETED,
-        time_iso=datetime.now(timezone.utc),
-        db=mock_db,
-    )
-
-    mock_db.update_job_status.assert_any_call(123, JobStatus.COMPLETED)
-
-
-def test_update_failed_status():
-    mock_db = MagicMock()
-    job = MagicMock()
-    job.id = 123
-    job.job_status = JobStatus.RUNNING
-    mock_db.get_job_by_external_id.return_value = job
-
-    update_batch_job_status(
-        batch_job_id="abc",
-        status=JobStatus.FAILED,
-        time_iso=datetime.now(timezone.utc),
-        db=mock_db,
-    )
-
-    mock_db.update_job_status.assert_any_call(123, JobStatus.FAILED)
-
-
-def test_update_duplicate_status():
-    mock_db = MagicMock()
-    job = MagicMock()
-    job.id = 123
-    job.job_status = JobStatus.RUNNING
-    mock_db.get_job_by_external_id.return_value = job
-
-    update_batch_job_status(
-        batch_job_id="abc",
-        status=JobStatus.RUNNING,
-        time_iso=datetime.now(timezone.utc),
-        db=mock_db,
-    )
-
-    mock_db.update_job_status.assert_not_called()
-
-
-def test_update_lower_priority_status():
-    mock_db = MagicMock()
-    job = MagicMock()
-    job.id = 123
-    job.job_status = JobStatus.COMPLETED
-    mock_db.get_job_by_external_id.return_value = job
-
-    update_batch_job_status(
-        batch_job_id="abc",
-        status=JobStatus.RUNNING,
+        status=new_status,
         time_iso=datetime.now(timezone.utc),
         db=mock_db,
     )

--- a/tests/cwms_batch_events/core/test_job_loggers.py
+++ b/tests/cwms_batch_events/core/test_job_loggers.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+
+from cwms_batch_events.core.job_logger.cloudwatch import CloudWatchJobLogger
+from cwms_batch_events.core.job_logger.s3 import S3JobLogger
+
+
+def test_s3_job_logger_reads_logs_from_bucket():
+    body = mock.Mock()
+    body.read.return_value = b"hello"
+    s3_client = mock.Mock()
+    s3_client.get_object.return_value = {"Body": body}
+
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.s3.boto3.client",
+        return_value=s3_client,
+    ), mock.patch("cwms_batch_events.core.job_logger.s3.S3_BUCKET", "bucket"):
+        logger = S3JobLogger()
+        logs = logger.get_logs_for_job(uuid4())
+
+    assert logs == "hello"
+
+
+def test_s3_job_logger_pushes_logs_to_bucket():
+    s3_client = mock.Mock()
+    job_id = uuid4()
+
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.s3.boto3.client",
+        return_value=s3_client,
+    ), mock.patch("cwms_batch_events.core.job_logger.s3.S3_BUCKET", "bucket"):
+        logger = S3JobLogger()
+        logger.push_logs_for_job(job_id, "hello")
+
+    s3_client.put_object.assert_called_once_with(
+        Bucket="bucket",
+        Key=f"logs/{job_id}.log",
+        Body=b"hello",
+    )
+
+
+def test_cloudwatch_job_logger_get_job_details_requires_existing_job():
+    db = mock.Mock()
+    db.get_job_by_id.return_value = None
+
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.cloudwatch.boto3.client",
+        side_effect=[mock.Mock(), mock.Mock()],
+    ):
+        logger = CloudWatchJobLogger(db)
+
+    with pytest.raises(ValueError, match="No job found"):
+        logger.get_job_details(uuid4())
+
+
+def test_cloudwatch_job_logger_requires_single_batch_job_match():
+    batch_client = mock.Mock()
+    batch_client.describe_jobs.return_value = {"jobs": []}
+
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.cloudwatch.boto3.client",
+        side_effect=[batch_client, mock.Mock()],
+    ):
+        logger = CloudWatchJobLogger(mock.Mock())
+
+    with pytest.raises(ValueError, match="No Batch jobs found"):
+        logger.get_batch_log_name("ext-123")
+
+
+def test_cloudwatch_job_logger_rejects_multiple_batch_jobs():
+    batch_client = mock.Mock()
+    batch_client.describe_jobs.return_value = {"jobs": [{}, {}]}
+
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.cloudwatch.boto3.client",
+        side_effect=[batch_client, mock.Mock()],
+    ):
+        logger = CloudWatchJobLogger(mock.Mock())
+
+    with pytest.raises(ValueError, match="Multiple jobs found"):
+        logger.get_batch_log_name("ext-123")
+
+
+def test_cloudwatch_job_logger_requires_external_job_id():
+    job_id = uuid4()
+    db = mock.Mock()
+    db.get_job_by_id.return_value = SimpleNamespace(
+        external_job_id=None,
+        office="SWT",
+    )
+
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.cloudwatch.boto3.client",
+        side_effect=[mock.Mock(), mock.Mock()],
+    ):
+        logger = CloudWatchJobLogger(db)
+
+    with pytest.raises(ValueError, match="No external_job_id found"):
+        logger.get_logs_for_job(job_id)
+
+
+def test_cloudwatch_job_logger_returns_joined_log_messages():
+    job_id = uuid4()
+    db = mock.Mock()
+    db.get_job_by_id.return_value = SimpleNamespace(
+        external_job_id="ext-123",
+        office="SWT",
+    )
+    batch_client = mock.Mock()
+    batch_client.describe_jobs.return_value = {
+        "jobs": [{"attempts": [{"container": {"logStreamName": "stream"}}]}]
+    }
+    logs_client = mock.Mock()
+    logs_client.get_log_events.return_value = {
+        "events": [{"message": "line 1"}, {"message": "line 2"}]
+    }
+
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.cloudwatch.boto3.client",
+        side_effect=[batch_client, logs_client],
+    ):
+        logger = CloudWatchJobLogger(db)
+        logs = logger.get_logs_for_job(job_id)
+
+    assert logs == "line 1\nline 2"
+    logs_client.get_log_events.assert_called_once_with(
+        logGroupName="ecs/cwms-batch/swt-jobs",
+        logStreamName="stream",
+        startFromHead=True,
+    )
+
+
+def test_cloudwatch_job_logger_push_logs_not_supported():
+    with mock.patch(
+        "cwms_batch_events.core.job_logger.cloudwatch.boto3.client",
+        side_effect=[mock.Mock(), mock.Mock()],
+    ):
+        logger = CloudWatchJobLogger(mock.Mock())
+
+    with pytest.raises(NotImplementedError):
+        logger.push_logs_for_job(uuid4(), "logs")

--- a/tests/cwms_batch_events/core/test_queue.py
+++ b/tests/cwms_batch_events/core/test_queue.py
@@ -1,0 +1,59 @@
+from unittest import mock
+from types import SimpleNamespace
+from uuid import uuid4
+
+from cwms_batch_events.core.models import JobSource, ScriptRunOptions
+from cwms_batch_events.core.queue import JobQueue, MESSAGE_VERSION
+
+
+def test_job_queue_initializes_sqs_resource_and_queue():
+    sqs = mock.Mock()
+    queue_obj = mock.Mock()
+    sqs.get_queue_by_name.return_value = queue_obj
+
+    with mock.patch(
+        "cwms_batch_events.core.queue.boto3.resource",
+        return_value=sqs,
+    ) as boto_resource, mock.patch(
+        "cwms_batch_events.core.queue.settings.sqs_endpoint_url",
+        "http://sqs",
+    ), mock.patch(
+        "cwms_batch_events.core.queue.settings.default_job_runner",
+        "batch",
+    ):
+        queue = JobQueue()
+
+    assert queue.queue is queue_obj
+    assert queue.runner_type == "batch"
+    boto_resource.assert_called_once_with("sqs", endpoint_url="http://sqs")
+    sqs.get_queue_by_name.assert_called_once_with(QueueName="cwms-batch-events")
+
+
+def test_create_job_message_uses_runner_type():
+    queue = JobQueue.__new__(JobQueue)
+    queue.runner_type = "docker-local"
+    payload = ScriptRunOptions(office="swt", repo_path="run.py", script_slug="script")
+    job_id = uuid4()
+
+    message = queue.create_job_message(job_id, "tester", JobSource.API, payload)
+
+    assert message.version == MESSAGE_VERSION
+    assert message.job_id == job_id
+    assert message.runner_type == "docker-local"
+    assert message.requested_by.username == "tester"
+    assert message.requested_by.source == JobSource.API
+    assert message.payload == payload
+
+
+def test_send_job_message_returns_message_id():
+    queue = JobQueue.__new__(JobQueue)
+    queue.runner_type = "docker-local"
+    queue.queue = SimpleNamespace(
+        send_message=lambda MessageBody: {"MessageId": "message-123"}
+    )
+    payload = ScriptRunOptions(office="swt", repo_path="run.py", script_slug="script")
+    message = queue.create_job_message(uuid4(), "tester", JobSource.API, payload)
+
+    response = queue.send_job_message(message)
+
+    assert response == "message-123"

--- a/tests/cwms_batch_events/core/test_utils.py
+++ b/tests/cwms_batch_events/core/test_utils.py
@@ -1,0 +1,15 @@
+from unittest import mock
+
+from cwms_batch_events.core.utils import BATCH_RUNNER_ID, LOCAL_RUNNER_ID, get_runner_id
+
+
+def test_get_runner_id_returns_local_runner_for_docker_local():
+    with mock.patch(
+        "cwms_batch_events.core.utils.settings.default_job_runner", "docker-local"
+    ):
+        assert str(get_runner_id()) == LOCAL_RUNNER_ID
+
+
+def test_get_runner_id_returns_batch_runner_by_default():
+    with mock.patch("cwms_batch_events.core.utils.settings.default_job_runner", "batch"):
+        assert str(get_runner_id()) == BATCH_RUNNER_ID

--- a/tests/cwms_batch_events/lambdas/test_batch_job_runner.py
+++ b/tests/cwms_batch_events/lambdas/test_batch_job_runner.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from unittest import mock
+
+from cwms_batch_events.lambdas.dispatch_job.job_runner.batch import BatchJobRunner
+from tests.factories import make_job_message
+
+
+def test_batch_job_runner_submits_expected_batch_job():
+    batch_client = mock.Mock()
+    batch_client.submit_job.return_value = {"jobId": "ext-123"}
+    fixed_now = datetime(2026, 4, 16, 12, 30)
+    message = make_job_message()
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.job_runner.batch.boto3.client",
+        return_value=batch_client,
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.job_runner.batch.datetime"
+    ) as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        runner = BatchJobRunner()
+        job_id = runner.run_job(message)
+
+    assert job_id == "ext-123"
+    batch_client.submit_job.assert_called_once_with(
+        jobName="cwms-swt-event-script-20260416-1230",
+        jobQueue="cwms-swd-jq",
+        jobDefinition="cwms-swt-jobs-jobdef",
+        containerOverrides={
+            "environment": [{"name": "OFFICE", "value": "swt"}],
+            "command": ["python", "/jobs/run.py"],
+        },
+        tags={"Office": "swt"},
+    )
+
+
+def test_batch_job_runner_uses_repo_path_name_when_slug_missing():
+    batch_client = mock.Mock()
+    batch_client.submit_job.return_value = {"jobId": "ext-123"}
+    fixed_now = datetime(2026, 4, 16, 12, 30)
+    message = make_job_message(
+        payload=make_job_message().payload.model_copy(update={"script_slug": None, "repo_path": "folder/my.script.py"})
+    )
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.job_runner.batch.boto3.client",
+        return_value=batch_client,
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.job_runner.batch.datetime"
+    ) as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        runner = BatchJobRunner()
+        runner.run_job(message)
+
+    assert batch_client.submit_job.call_args.kwargs["jobName"] == (
+        "cwms-swt-event-my_script_py-20260416-1230"
+    )

--- a/tests/cwms_batch_events/lambdas/test_dispatcher_lambda.py
+++ b/tests/cwms_batch_events/lambdas/test_dispatcher_lambda.py
@@ -1,0 +1,122 @@
+import json
+from unittest import mock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from cwms_batch_events.lambdas.dispatch_job.dispatcher import (
+    MissingJobRunner,
+    dispatch_job,
+    get_internal_token,
+    lambda_handler,
+)
+from tests.factories import make_job_message
+
+
+def test_dispatch_job_uses_batch_runner():
+    message = make_job_message()
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.BatchJobRunner"
+    ) as runner_cls:
+        runner_cls.return_value.run_job.return_value = "ext-123"
+
+        external_job_id = dispatch_job(message)
+
+    assert external_job_id == "ext-123"
+    runner_cls.return_value.run_job.assert_called_once_with(message)
+
+
+def test_dispatch_job_rejects_unknown_runner_type():
+    message = make_job_message()
+    message.runner_type = "unknown"
+
+    with pytest.raises(MissingJobRunner):
+        dispatch_job(message)
+
+
+def test_get_internal_token_reads_and_caches_secret():
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher._cached_internal_token", None
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.APP_SECRETS_ARN", "arn"
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.secrets_client"
+    ) as secrets_client:
+        secrets_client.get_secret_value.return_value = {
+            "SecretString": json.dumps({"APP_KEY": "secret"})
+        }
+
+        first = get_internal_token()
+        second = get_internal_token()
+
+    assert first == "secret"
+    assert second == "secret"
+    secrets_client.get_secret_value.assert_called_once_with(SecretId="arn")
+
+
+def test_get_internal_token_requires_secret_string():
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher._cached_internal_token", None
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.secrets_client"
+    ) as secrets_client:
+        secrets_client.get_secret_value.return_value = {"SecretString": ""}
+
+        with pytest.raises(RuntimeError, match="SecretString"):
+            get_internal_token()
+
+
+def test_lambda_handler_processes_messages_and_binds_external_job_id():
+    message = make_job_message()
+    response = mock.Mock(status_code=204, text="")
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.get_internal_token",
+        return_value="secret",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.dispatch_job",
+        return_value="ext-123",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.requests.post",
+        return_value=response,
+    ) as requests_post, mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.API_BASE_URL",
+        "http://events",
+    ):
+        lambda_handler({"Records": [{"body": message.model_dump_json()}]}, None)
+
+    requests_post.assert_called_once()
+    assert requests_post.call_args.kwargs["json"] == {"external_job_id": "ext-123"}
+
+
+def test_lambda_handler_raises_when_api_rejects_message():
+    message = make_job_message()
+    response = mock.Mock(status_code=500, text="bad")
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.get_internal_token",
+        return_value="secret",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.dispatch_job",
+        return_value="ext-123",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.requests.post",
+        return_value=response,
+    ):
+        with pytest.raises(RuntimeError, match="Events API rejected message"):
+            lambda_handler({"Records": [{"body": message.model_dump_json()}]}, None)
+
+
+def test_lambda_handler_reraises_batch_submit_error():
+    message = make_job_message()
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.get_internal_token",
+        return_value="secret",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.dispatch_job.dispatcher.dispatch_job",
+        side_effect=ClientError({"Error": {"Code": "Oops", "Message": "bad"}}, "Submit"),
+    ):
+        with pytest.raises(ClientError):
+            lambda_handler({"Records": [{"body": message.model_dump_json()}]}, None)

--- a/tests/cwms_batch_events/lambdas/test_status_updater.py
+++ b/tests/cwms_batch_events/lambdas/test_status_updater.py
@@ -1,0 +1,164 @@
+import json
+from unittest import mock
+
+import pytest
+import requests
+from botocore.exceptions import ClientError
+
+from cwms_batch_events.lambdas.update_batch_job_status.status_updater import (
+    get_internal_token,
+    lambda_handler,
+)
+
+
+def test_get_internal_token_reads_and_caches_secret():
+    with mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater._cached_internal_token",
+        None,
+    ), mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.APP_SECRETS_ARN",
+        "arn",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.secrets_client"
+    ) as secrets_client:
+        secrets_client.get_secret_value.return_value = {
+            "SecretString": json.dumps({"APP_KEY": "secret"})
+        }
+
+        first = get_internal_token()
+        second = get_internal_token()
+
+    assert first == "secret"
+    assert second == "secret"
+    secrets_client.get_secret_value.assert_called_once_with(SecretId="arn")
+
+
+def test_get_internal_token_re_raises_client_error():
+    error = ClientError({"Error": {"Code": "Oops", "Message": "bad"}}, "GetSecretValue")
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater._cached_internal_token",
+        None,
+    ), mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.secrets_client"
+    ) as secrets_client:
+        secrets_client.get_secret_value.side_effect = error
+
+        with pytest.raises(ClientError):
+            get_internal_token()
+
+
+def test_lambda_handler_ignores_non_event_jobs():
+    with mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.requests.post"
+    ) as requests_post:
+        lambda_handler(
+            {
+                "detail": {
+                    "jobName": "cwms-swt-manual-script",
+                    "jobId": "batch-123",
+                    "status": "RUNNING",
+                },
+                "time": "2026-04-16T12:00:00Z",
+            },
+            None,
+        )
+
+    requests_post.assert_not_called()
+
+
+def test_lambda_handler_ignores_unsupported_status():
+    with mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.requests.post"
+    ) as requests_post:
+        lambda_handler(
+            {
+                "detail": {
+                    "jobName": "cwms-swt-event-script",
+                    "jobId": "batch-123",
+                    "status": "STARTING",
+                },
+                "time": "2026-04-16T12:00:00Z",
+            },
+            None,
+        )
+
+    requests_post.assert_not_called()
+
+
+def test_lambda_handler_posts_translated_status_to_events_api():
+    response = mock.Mock(status_code=204, text="")
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.get_internal_token",
+        return_value="secret",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.requests.post",
+        return_value=response,
+    ) as requests_post, mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.API_BASE_URL",
+        "http://events/api",
+    ):
+        lambda_handler(
+            {
+                "detail": {
+                    "jobName": "cwms-swt-event-script",
+                    "jobId": "batch-123",
+                    "status": "SUCCEEDED",
+                },
+                "time": "2026-04-16T12:00:00Z",
+            },
+            None,
+        )
+
+    requests_post.assert_called_once()
+    assert requests_post.call_args.kwargs["json"] == {
+        "status": "Completed",
+        "event_time": "2026-04-16T12:00:00Z",
+    }
+
+
+def test_lambda_handler_re_raises_request_exceptions():
+    with mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.get_internal_token",
+        return_value="secret",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.requests.post",
+        side_effect=requests.RequestException("boom"),
+    ):
+        with pytest.raises(requests.RequestException):
+            lambda_handler(
+                {
+                    "detail": {
+                        "jobName": "cwms-swt-event-script",
+                        "jobId": "batch-123",
+                        "status": "RUNNING",
+                    },
+                    "time": "2026-04-16T12:00:00Z",
+                },
+                None,
+            )
+
+
+def test_lambda_handler_raises_when_events_api_rejects_message():
+    response = mock.Mock(status_code=500, text="bad")
+
+    with mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.get_internal_token",
+        return_value="secret",
+    ), mock.patch(
+        "cwms_batch_events.lambdas.update_batch_job_status.status_updater.requests.post",
+        return_value=response,
+    ):
+        with pytest.raises(RuntimeError, match="Events API rejected message"):
+            lambda_handler(
+                {
+                    "detail": {
+                        "jobName": "cwms-swt-event-script",
+                        "jobId": "batch-123",
+                        "status": "RUNNING",
+                    },
+                    "time": "2026-04-16T12:00:00Z",
+                },
+                None,
+            )

--- a/tests/cwms_batch_events/local/test_executor.py
+++ b/tests/cwms_batch_events/local/test_executor.py
@@ -1,0 +1,61 @@
+from unittest import mock
+
+import pytest
+
+from cwms_batch_events.core.models import (
+    JobStatus,
+)
+from cwms_batch_events.local.executor import LocalExecutor
+from tests.factories import make_job_message
+
+
+def test_local_executor_marks_completed_job_and_persists_logs():
+    db = mock.Mock()
+    logger = mock.Mock()
+    message = make_job_message(runner_type="docker-local")
+    container = mock.Mock()
+    container.wait.return_value = {"StatusCode": 0}
+    container.logs.return_value = b"hello"
+    client = mock.Mock()
+    client.containers.run.return_value = container
+
+    with mock.patch("docker.client.from_env", return_value=client):
+        executor = LocalExecutor(db, logger)
+        executor.run_job(message)
+
+    assert db.update_job_status.call_args_list[0].args[1] == JobStatus.RUNNING
+    assert db.update_job_status.call_args_list[-1].args[1] == JobStatus.COMPLETED
+    logger.push_logs_for_job.assert_called_once_with(message.job_id, "hello")
+    container.remove.assert_called_once_with()
+
+
+def test_local_executor_marks_failed_job_on_nonzero_status():
+    db = mock.Mock()
+    logger = mock.Mock()
+    message = make_job_message(runner_type="docker-local")
+    container = mock.Mock()
+    container.wait.return_value = {"StatusCode": 1}
+    container.logs.return_value = b"hello"
+    client = mock.Mock()
+    client.containers.run.return_value = container
+
+    with mock.patch("docker.client.from_env", return_value=client):
+        executor = LocalExecutor(db, logger)
+        executor.run_job(message)
+
+    assert db.update_job_status.call_args_list[-1].args[1] == JobStatus.FAILED
+
+
+def test_local_executor_marks_failed_and_reraises_on_exception():
+    db = mock.Mock()
+    logger = mock.Mock()
+    message = make_job_message(runner_type="docker-local")
+    client = mock.Mock()
+    client.containers.run.side_effect = RuntimeError("boom")
+
+    with mock.patch("docker.client.from_env", return_value=client):
+        executor = LocalExecutor(db, logger)
+        with pytest.raises(RuntimeError, match="boom"):
+            executor.run_job(message)
+
+    assert db.update_job_status.call_args_list[-1].args[1] == JobStatus.FAILED

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from cwms_batch_events.core.auth.user.models import User
+from cwms_batch_events.core.models import (
+    JobMessage,
+    JobRecord,
+    JobRequestedBy,
+    JobSource,
+    JobStatus,
+    ScriptRead,
+    ScriptRunOptions,
+)
+
+
+def make_user(**overrides) -> User:
+    return User(
+        username=overrides.pop("username", "test-user"),
+        offices=overrides.pop("offices", ["SWT", "LRH"]),
+        admin_offices=overrides.pop("admin_offices", ["SWT"]),
+        roles=overrides.pop(
+            "roles", {"SWT": ["CWMS Users"], "LRH": ["CWMS Users"]}
+        ),
+        **overrides,
+    )
+
+
+def make_job_record(**overrides) -> JobRecord:
+    return JobRecord(
+        id=overrides.pop("id", uuid4()),
+        script_id=overrides.pop("script_id", uuid4()),
+        script_name=overrides.pop("script_name", "Test Script"),
+        script_slug=overrides.pop("script_slug", "test-script"),
+        job_status=overrides.pop("job_status", JobStatus.PENDING),
+        username=overrides.pop("username", "test-user"),
+        office=overrides.pop("office", "SWT"),
+        repo_path=overrides.pop("repo_path", "run.py"),
+        execution_type=overrides.pop("execution_type", "batch"),
+        created_time=overrides.pop("created_time", datetime.now(timezone.utc)),
+        run_time=overrides.pop("run_time", None),
+        end_time=overrides.pop("end_time", None),
+        job_runner_id=overrides.pop("job_runner_id", uuid4()),
+        external_job_id=overrides.pop("external_job_id", None),
+        **overrides,
+    )
+
+
+def make_script_read(**overrides) -> ScriptRead:
+    now = datetime.now(timezone.utc)
+    return ScriptRead(
+        id=overrides.pop("id", uuid4()),
+        slug=overrides.pop("slug", "test-script"),
+        office=overrides.pop("office", "SWT"),
+        name=overrides.pop("name", "Test Script"),
+        description=overrides.pop("description", "desc"),
+        repo_path=overrides.pop("repo_path", "run.py"),
+        execution_type=overrides.pop("execution_type", "batch"),
+        active=overrides.pop("active", True),
+        roles=overrides.pop("roles", []),
+        job_runners=overrides.pop("job_runners", []),
+        created_time=overrides.pop("created_time", now),
+        updated_time=overrides.pop("updated_time", now),
+        **overrides,
+    )
+
+
+def make_script_payload(**overrides) -> dict:
+    return {
+        "name": overrides.pop("name", "Test Script"),
+        "description": overrides.pop("description", "desc"),
+        "repoPath": overrides.pop("repoPath", "run.py"),
+        "executionType": overrides.pop("executionType", "batch"),
+        "active": overrides.pop("active", True),
+        "roles": overrides.pop("roles", []),
+        "jobRunners": overrides.pop("jobRunners", []),
+        **overrides,
+    }
+
+
+def make_script_create_payload(**overrides) -> dict:
+    return {
+        "office": overrides.pop("office", "SWT"),
+        **make_script_payload(**overrides),
+    }
+
+
+def make_job_message(**overrides) -> JobMessage:
+    return JobMessage(
+        version=overrides.pop("version", "1.0"),
+        job_id=overrides.pop("job_id", uuid4()),
+        runner_type=overrides.pop("runner_type", "batch"),
+        requested_by=overrides.pop(
+            "requested_by",
+            JobRequestedBy(username="tester", source=JobSource.API),
+        ),
+        created_at=overrides.pop("created_at", datetime.now(timezone.utc)),
+        payload=overrides.pop(
+            "payload",
+            ScriptRunOptions(
+                office="swt",
+                repo_path="run.py",
+                script_slug="script",
+            ),
+        ),
+        **overrides,
+    )


### PR DESCRIPTION

This takes test coverage to 77% from the outputted HTML coverage report. 

It does not cover any database (postgres) testing. 

Created CI to ensure failed tests block PR on cwbi-dev, cwbi-test, cwbi-prod

Documented in CONTRIBUTING.md

Adds unit tests to all routes:
- API route
- API dependency wiring
- Auth service
- Auth user dependency
- Auth JWT/helper
- Core processing
- Queue
- Job logger
- Local dispatcher
- Local executor
- Lambda dispatcher
- Lambda status updater
- Batch job runner

