### PR TITLE
Add Codespaces development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+# The upstream image currently carries a stale Yarn apt source. Node is installed
+# by the maintained dev-container feature, so this source is not needed here.
+RUN rm -f /etc/apt/sources.list.d/yarn.list
+
+COPY requirements.txt requirements-dev.txt /tmp/cwms-batch-events-requirements/
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir \
+        --requirement /tmp/cwms-batch-events-requirements/requirements.txt \
+        --requirement /tmp/cwms-batch-events-requirements/requirements-dev.txt \
+    && rm -rf /tmp/cwms-batch-events-requirements

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,61 @@
+{
+  "name": "CWMS Batch Events",
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "version": "latest",
+      "moby": true
+    }
+  },
+  "remoteEnv": {
+    "PYTHONPATH": "${containerWorkspaceFolder}"
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "forwardPorts": [
+    5173,
+    8000,
+    9001,
+    9325
+  ],
+  "portsAttributes": {
+    "5173": {
+      "label": "Batch Events UI"
+    },
+    "8000": {
+      "label": "Batch Events API"
+    },
+    "9001": {
+      "label": "MinIO Console"
+    },
+    "9325": {
+      "label": "ElasticMQ UI"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestArgs": [
+          "tests"
+        ],
+        "typescript.tsdk": "ui/node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm --prefix ui ci
+
+for attempt in {1..30}; do
+  if docker info >/dev/null 2>&1; then
+    break
+  fi
+  if [[ "${attempt}" == "30" ]]; then
+    echo "Docker did not become ready in time." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+docker network inspect cwms >/dev/null 2>&1 || docker network create cwms >/dev/null
+
+python --version
+node --version
+npm --version
+docker compose version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,22 @@ GitHub Codespaces is the quickest supported setup path. The repository developme
 
 The default local stack uses mock authentication and local-only service credentials. Do not add production credentials to the development container configuration or tracked files.
 
+### Local Dev Container on Windows
+
+Install and start Docker Desktop in Linux container mode, and ensure Node.js and npm are available. From a PowerShell prompt at the repository root, build and start the development container on the local Docker host with:
+
+```powershell
+npx -y @devcontainers/cli up --workspace-folder .
+```
+
+Open a shell in the running development container with:
+
+```powershell
+npx -y @devcontainers/cli exec --workspace-folder . bash
+```
+
+Docker Desktop runs the development container itself. The development container's Docker-in-Docker feature provides the isolated Docker daemon used by the project's Compose stack.
+
 ## Pre-reqs
 * VM 
 * Python 3.12+ (Pref with `pyenv`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributions
 
+## Codespaces
+
+GitHub Codespaces is the quickest supported setup path. The repository development container installs the Python and UI dependencies and prepares the Docker network used by `docker-compose.yml`. After creation, run `docker compose up --build` for the API and backing services, and run `npm --prefix ui run dev -- --host 0.0.0.0` in another terminal for the UI.
+
+The default local stack uses mock authentication and local-only service credentials. Do not add production credentials to the development container configuration or tracked files.
+
 ## Pre-reqs
 * VM 
 * Python 3.12+ (Pref with `pyenv`)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@ CWMS Batch Events provides users an API and user interface to execute water mana
 
 To get your local environment setup and/or make contributions please see the contributions documentation: [CONTRIBUTING.md](https://github.com/USACE-WaterManagement/cwms-batch-events/blob/cwbi-dev/CONTRIBUTING.md)
 
+### GitHub Codespaces
+
+The repository's development container prepares a complete environment for GitHub Codespaces, including Python 3.12 and all test dependencies, Node.js 22 and the UI dependencies, Docker Compose with an isolated Docker daemon, the external `cwms` Docker network required by the local stack, and editor support for Python, TypeScript, ESLint, and Docker.
+
+Create a Codespace for this repository and wait for its setup to finish. The mounted checkout is used directly for Python imports, and `ui/node_modules` is installed from the committed lockfile. No credentials or repository secrets are required for the default mock-user development flow.
+
+Verify the environment with:
+
+```bash
+python -m pytest -q
+npm --prefix ui run lint
+npm --prefix ui run build
+docker compose config --quiet
+```
+
+Start the local service stack and UI in separate terminals:
+
+```bash
+docker compose up --build
+npm --prefix ui run dev -- --host 0.0.0.0
+```
+
+Codespaces forwards the UI, API, MinIO console, and ElasticMQ UI ports automatically. Use the forwarded URLs shown in the **Ports** panel rather than assuming `localhost` from outside the Codespace.
+
 
 ### Local Development Setup
 
@@ -32,4 +56,3 @@ Available district scripts are managed within the cwms-batch application itself 
 
 #### User Interface
 The user interface is deployed locally as a vite development server.  To run it, simply enter the `ui` directory and run `npm run dev`.
-

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ npm --prefix ui run dev -- --host 0.0.0.0
 
 Codespaces forwards the UI, API, MinIO console, and ElasticMQ UI ports automatically. Use the forwarded URLs shown in the **Ports** panel rather than assuming `localhost` from outside the Codespace.
 
+#### Run the Dev Container locally on Windows
+
+Install and start Docker Desktop in Linux container mode, and ensure Node.js and npm are available. From a PowerShell prompt at the repository root, build and start the development container on the local Docker host with:
+
+```powershell
+npx -y @devcontainers/cli up --workspace-folder .
+```
+
+Open a shell in the running development container with:
+
+```powershell
+npx -y @devcontainers/cli exec --workspace-folder . bash
+```
+
+Docker Desktop runs the development container itself. The development container's Docker-in-Docker feature provides the isolated Docker daemon used by the project's Compose stack.
+
 
 ### Local Development Setup
 

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
+vite.config.d.ts
+vite.config.js
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary

- add a reproducible GitHub Codespaces development container for the Batch Events API and UI
- install Python 3.12 dependencies, Node.js 22, locked UI dependencies, and Docker Compose with an isolated Docker daemon
- prepare the external `cwms` Docker network required by the local Compose stack
- configure forwarded ports and editor tooling for Python, TypeScript, ESLint, and Docker
- document Codespaces setup, verification, service startup, and credential boundaries
- ignore TypeScript build metadata generated by the documented UI build

## Why

Developers currently need to install and align Python, Node.js, Docker, project dependencies, UI dependencies, and the local Docker network manually. The development container makes a new self-hosted Codespace ready for tests and local full-stack development while retaining mock authentication and local-only service credentials by default.

## Validation

- Dev Container image build succeeded
- Dev Container lifecycle startup and post-create setup succeeded
- `python -m pytest -q` — 111 passed, 1 existing dependency deprecation warning
- `npm --prefix ui run lint` — passed
- `npm --prefix ui run build` — passed with existing asset-resolution and chunk-size warnings
- `docker compose config --quiet` — passed
- `docker compose up --detach --build` — built and started the API, dispatcher, PostgreSQL, MinIO, Flyway, and ElasticMQ
- PostgreSQL reported healthy and `GET /health` returned `{status:ok}`