### PR TITLE
Harden container images against known vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
+ARG PYTHON_VERSION=3.13.15
+ARG ALPINE_VERSION=3.23
+
 # Builder
 
-FROM python:3.13-slim AS builder
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION} AS builder
 
-RUN apt-get update && apt-get install -y gcc
+RUN apk add --no-cache build-base postgresql-dev
 
 WORKDIR /code
 
@@ -16,14 +19,20 @@ RUN pip install --no-cache-dir -r ${REQ_FILE}
 
 # Runtime
 
-FROM python:3.13-slim
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
+
+RUN apk upgrade --no-cache
 
 RUN addgroup --system appuser \
- && adduser  --system --ingroup appuser --uid 10001 appuser
+ && adduser --system --ingroup appuser --uid 10001 appuser
 
 WORKDIR /code
 
 COPY --from=builder /usr/local /usr/local
+
+# Packaging tools are not needed at runtime and include vendored libraries that
+# are independently reported by container vulnerability scanners.
+RUN python -m pip uninstall --yes pip setuptools wheel
 
 COPY ./cwms_batch_events ./cwms_batch_events
 

--- a/infra/dispatcher/Dockerfile
+++ b/infra/dispatcher/Dockerfile
@@ -1,17 +1,27 @@
-FROM python:3.13-slim
+ARG PYTHON_VERSION=3.13.15
+ARG ALPINE_VERSION=3.23
+
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION} AS builder
 
 WORKDIR /app
 
-# Install system deps (psycopg2, docker SDK)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       gcc \
-       libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache build-base postgresql-dev
 
 COPY requirements.txt .
 COPY requirements-dev.txt .
 RUN pip install --no-cache-dir -r requirements-dev.txt
+
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
+
+RUN apk upgrade --no-cache
+
+WORKDIR /app
+
+COPY --from=builder /usr/local /usr/local
+
+# Packaging tools are not needed at runtime and include vendored libraries that
+# are independently reported by container vulnerability scanners.
+RUN python -m pip uninstall --yes pip setuptools wheel
 
 COPY cwms_batch_events ./cwms_batch_events
 COPY infra/dispatcher ./infra/dispatcher

--- a/infra/migration/dockerfile
+++ b/infra/migration/dockerfile
@@ -1,10 +1,60 @@
 ARG BUILDER=ghcr.io/cwbi-apps/flyway
-ARG BUILDER_TAG=latest
+ARG BUILDER_TAG=13.3.0
+ARG HTTP_CORE_VERSION=5.4.3
+ARG HTTP_CORE_SHA256=18bfbbabb478dfb67f31aeaf428c387f3c3df654582e1309f708ee1f3086830a
+ARG HTTP_CORE_H2_SHA256=c7db7026b8e2dea39132b04a6069f6671e2858309b20a146ec5c7dd6ed73a0b6
+ARG HTTP_CLIENT_VERSION=5.6.3
+ARG HTTP_CLIENT_SHA256=80712ff129210d7c73d9fcc1195cbee5c3c34744965c7a05ea107b3648922f18
+ARG NETTY_CODEC_HTTP_VERSION=4.2.17.Final
+ARG NETTY_CODEC_HTTP_SHA256=a5bde91ac82ab90579df6559c0bd7ea6ae37460e3f18116ab4122194283b3669
+
+FROM alpine:3.22 AS httpcore
+
+ARG HTTP_CORE_VERSION
+ARG HTTP_CORE_SHA256
+ARG HTTP_CORE_H2_SHA256
+ARG HTTP_CLIENT_VERSION
+ARG HTTP_CLIENT_SHA256
+ARG NETTY_CODEC_HTTP_VERSION
+ARG NETTY_CODEC_HTTP_SHA256
+
+RUN wget -q -O /tmp/httpcore5.jar \
+      "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/${HTTP_CORE_VERSION}/httpcore5-${HTTP_CORE_VERSION}.jar" \
+ && wget -q -O /tmp/httpcore5-h2.jar \
+      "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/${HTTP_CORE_VERSION}/httpcore5-h2-${HTTP_CORE_VERSION}.jar" \
+ && wget -q -O /tmp/httpclient5.jar \
+      "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/${HTTP_CLIENT_VERSION}/httpclient5-${HTTP_CLIENT_VERSION}.jar" \
+ && wget -q -O /tmp/netty-codec-http.jar \
+      "https://repo.maven.apache.org/maven2/io/netty/netty-codec-http/${NETTY_CODEC_HTTP_VERSION}/netty-codec-http-${NETTY_CODEC_HTTP_VERSION}.jar" \
+ && echo "${HTTP_CORE_SHA256}  /tmp/httpcore5.jar" | sha256sum -c - \
+ && echo "${HTTP_CORE_H2_SHA256}  /tmp/httpcore5-h2.jar" | sha256sum -c - \
+ && echo "${HTTP_CLIENT_SHA256}  /tmp/httpclient5.jar" | sha256sum -c - \
+ && echo "${NETTY_CODEC_HTTP_SHA256}  /tmp/netty-codec-http.jar" | sha256sum -c -
 
 # *~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~
 # FROM builder
 # *~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~
 FROM ${BUILDER}:${BUILDER_TAG} AS builder
+
+ARG HTTP_CORE_VERSION
+ARG HTTP_CORE_SHA256
+ARG HTTP_CORE_H2_SHA256
+ARG HTTP_CLIENT_VERSION
+ARG NETTY_CODEC_HTTP_VERSION
+
+COPY --from=httpcore /tmp/httpcore5.jar /tmp/httpcore5.jar
+COPY --from=httpcore /tmp/httpcore5-h2.jar /tmp/httpcore5-h2.jar
+COPY --from=httpcore /tmp/httpclient5.jar /tmp/httpclient5.jar
+COPY --from=httpcore /tmp/netty-codec-http.jar /tmp/netty-codec-http.jar
+
+RUN apk add --no-cache --upgrade busybox=1.38.0-r1 libcrypto3 libssl3 \
+ && rm -f /flyway/drivers/cassandra/httpcore5-*.jar \
+ && rm -f /flyway/drivers/cassandra/httpclient5-*.jar \
+ && rm -f /flyway/lib/netty/netty-codec-http-[0-9]*.jar \
+ && mv /tmp/httpcore5.jar "/flyway/drivers/cassandra/httpcore5-${HTTP_CORE_VERSION}.jar" \
+ && mv /tmp/httpcore5-h2.jar "/flyway/drivers/cassandra/httpcore5-h2-${HTTP_CORE_VERSION}.jar" \
+ && mv /tmp/httpclient5.jar "/flyway/drivers/cassandra/httpclient5-${HTTP_CLIENT_VERSION}.jar" \
+ && mv /tmp/netty-codec-http.jar "/flyway/lib/netty/netty-codec-http-${NETTY_CODEC_HTTP_VERSION}.jar"
 
 # env vars for FLYWAY
 ENV FLYWAY_EDITION=community


### PR DESCRIPTION
Updates the API and dispatcher runtimes to Python 3.13.15 on Alpine 3.23, removes unneeded runtime packaging tools, and pins patched Flyway image dependencies with checksum verification. Local validation: all three production images built successfully; Trivy reported zero vulnerabilities across the final images; 111 Python tests passed; API health check returned 200; UI lint and production build passed.